### PR TITLE
Potential fix for #14 and #1

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/handler/CreativeMenuHandler.java
+++ b/src/main/java/flaxbeard/cyberware/common/handler/CreativeMenuHandler.java
@@ -194,7 +194,7 @@ public class CreativeMenuHandler
 			}
 
 			// TODO: Reflection
-			Method tab = ReflectionHelper.findMethod(GuiContainerCreative.class,"setCurrentCreativeTab", null, CreativeTabs.class);
+			Method tab = ReflectionHelper.findMethod(GuiContainerCreative.class,"setCurrentCreativeTab", "func_147050_b", CreativeTabs.class);
 			try
 			{
 				tab.invoke(gui, Cyberware.creativeTab);

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemMuscleUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemMuscleUpgrade.java
@@ -175,8 +175,8 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 		}
 	}
 	
-	private Map<Integer, Boolean> lastBoostSpeed = new HashMap<Integer, Boolean>();
-	private Map<Integer, Boolean> lastBoostStrength = new HashMap<Integer, Boolean>();
+	private Map<UUID, Boolean> lastBoostSpeed = new HashMap<UUID, Boolean>();
+	private Map<UUID, Boolean> lastBoostStrength = new HashMap<UUID, Boolean>();
 
 	@SubscribeEvent(priority=EventPriority.NORMAL)
 	public void handleLivingUpdate(CyberwareUpdateEvent event)
@@ -196,24 +196,21 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 					//e.moveRelative(0F, .5F, 0.075F);
 					e.moveRelative(0F, .5F, 0.075F, 0.0F);
 				}
-				
-				if (!last)
-				{
-					this.onAdded(e, test);
-				}
+
+				this.onAdded(e, test);
+
 			}
-			else if (last)
+			else
 			{
 				this.onRemoved(e, test);
 			}
 			
-			lastBoostStrength.put(e.getEntityId(), powerUsed);
+			lastBoostStrength.put(e.getUniqueID(), powerUsed);
 		}
 		else
 		{
 			this.onRemoved(e, test);
-
-			lastBoostStrength.remove(e.getEntityId());
+			lastBoostStrength.remove(e.getUniqueID());
 		}
 		
 		test = new ItemStack(this, 1, 0);
@@ -230,33 +227,31 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 				this.onRemoved(e, test);
 			}
 			
-			lastBoostSpeed.put(e.getEntityId(), powerUsed);
+			lastBoostSpeed.put(e.getUniqueID(), powerUsed);
 		}
 		else 
 		{
-
 			this.onRemoved(e, test);
-			
-			lastBoostSpeed.remove(e.getEntityId());
+			lastBoostSpeed.remove(e.getUniqueID());
 		}
 	}
 	
 	private boolean getLastBoostStrength(EntityLivingBase e)
 	{
-		if (!lastBoostStrength.containsKey(e.getEntityId()))
+		if (!lastBoostStrength.containsKey(e.getUniqueID()))
 		{
-			lastBoostStrength.put(e.getEntityId(), true);
+			lastBoostStrength.put(e.getUniqueID(), true);
 		}
-		return lastBoostStrength.get(e.getEntityId());
+		return lastBoostStrength.get(e.getUniqueID());
 	}
 	
 	private boolean getLastBoostSpeed(EntityLivingBase e)
 	{
-		if (!lastBoostSpeed.containsKey(e.getEntityId()))
+		if (!lastBoostSpeed.containsKey(e.getUniqueID()))
 		{
-			lastBoostSpeed.put(e.getEntityId(), true);
+			lastBoostSpeed.put(e.getUniqueID(), true);
 		}
-		return lastBoostSpeed.get(e.getEntityId());
+		return lastBoostSpeed.get(e.getUniqueID());
 	}
 	
 	@Override

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemSkinUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemSkinUpgrade.java
@@ -1,9 +1,6 @@
 package flaxbeard.cyberware.common.item;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 
 import net.minecraft.enchantment.EnchantmentThorns;
 import net.minecraft.entity.Entity;
@@ -53,8 +50,8 @@ public class ItemSkinUpgrade extends ItemCyberware
 		}
 	}
 	
-	private Map<Integer, Boolean> lastImmuno = new HashMap<Integer, Boolean>();
-	private static Map<Integer, Collection<PotionEffect>> potions = new HashMap<Integer, Collection<PotionEffect>>();
+	private Map<UUID, Boolean> lastImmuno = new HashMap<UUID, Boolean>();
+	private static Map<UUID, Collection<PotionEffect>> potions = new HashMap<UUID, Collection<PotionEffect>>();
 
 	@SubscribeEvent(priority = EventPriority.HIGH)
 	public void handleMissingEssentials(CyberwareUpdateEvent event)
@@ -97,22 +94,24 @@ public class ItemSkinUpgrade extends ItemCyberware
 					}
 				}
 			}
-			potions.put(e.getEntityId(), e.getActivePotionEffects());
+
+			lastImmuno.put(e.getUniqueID(),powerUsed);
+			potions.put(e.getUniqueID(), e.getActivePotionEffects());
 		}
 		else
 		{
-			lastImmuno.remove(e.getEntityId());
-			potions.remove(e.getEntityId());
+			lastImmuno.remove(e.getUniqueID());
+			potions.remove(e.getUniqueID());
 		}
 	}
 	
 	private boolean lastImmuno(EntityLivingBase e)
 	{
-		if (!lastImmuno.containsKey(e.getEntityId()))
+		if (!lastImmuno.containsKey(e.getUniqueID()))
 		{
-			lastImmuno.put(e.getEntityId(), true);
+			lastImmuno.put(e.getUniqueID(), true);
 		}
-		return lastImmuno.get(e.getEntityId());
+		return lastImmuno.get(e.getUniqueID());
 	}
 	
 	@Override


### PR DESCRIPTION
This actually has two commits, the first one is a duplicate of a fix you've already pushed for the creative tab.

The main bit however is changing some of the logic for some Muscle and Skin augments.
Three augments, Myomer Muscle Replacements, Wired Reflexes, and Targeted Immunosuppressant all used a similar way of tracking if an entity had previously paid the energy cost of an augment and could all cause a NPE with a ticking entity exception. I believe this crash was because of the Map used to track entity power usage.

There were two changes made to those augments. Firstly, I updated the Maps to use UUID instead of Integer. UUIDs are unique, the int IDs are not. Secondly,  I made sure those maps actually updated. 

Previously they always evaluated true never accounting for if the player did not in fact have enough energy to pay for an augment. They should now update their values every time the player actually has to pay the augment energy usage cost.

I've run this as a test instance for about 8 hours locally with no crash. These were intermittent crashes however so I'm not sure this fixes it 100% but so far so good.