### PR TITLE
Fix Forge Energy Support for the Charger, fixes An-Sar/Cyberware#17

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/block/tile/TileEntityCharger.java
+++ b/src/main/java/flaxbeard/cyberware/common/block/tile/TileEntityCharger.java
@@ -19,6 +19,7 @@ import net.minecraft.util.ITickable;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.CapabilityInject;
+import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 import net.minecraftforge.fml.common.Optional;
 import flaxbeard.cyberware.api.CyberwareAPI;
@@ -84,6 +85,9 @@ public class TileEntityCharger extends TileEntity implements ITickable, IEnergyR
 		{
 			return (T) this.container;
 		}
+		
+		if(capability ==CapabilityEnergy.ENERGY)
+			return (T) this;
 			
 		return super.getCapability(capability, facing);
 	}
@@ -91,7 +95,7 @@ public class TileEntityCharger extends TileEntity implements ITickable, IEnergyR
 	@Override
 	public boolean hasCapability(Capability<?> capability, EnumFacing facing)
 	{
-		if (capability == TESLA_CONSUMER || capability == TESLA_PRODUCER || capability == TESLA_HOLDER)
+		if (capability == TESLA_CONSUMER || capability == TESLA_PRODUCER || capability == TESLA_HOLDER || capability == CapabilityEnergy.ENERGY)
 		{
 			return true;
 		}

--- a/src/main/java/flaxbeard/cyberware/common/block/tile/TileEntityCharger.java
+++ b/src/main/java/flaxbeard/cyberware/common/block/tile/TileEntityCharger.java
@@ -86,7 +86,7 @@ public class TileEntityCharger extends TileEntity implements ITickable, IEnergyR
 			return (T) this.container;
 		}
 		
-		if(capability ==CapabilityEnergy.ENERGY)
+		if(capability == CapabilityEnergy.ENERGY)
 			return (T) this;
 			
 		return super.getCapability(capability, facing);


### PR DESCRIPTION
TileEntityCharge was properly implementing the methods for Forge Energy's IEnergyStorage, it just didn't have the proper has/getCapability checks accounting for CapabilityEnergy.ENERGY

