### PR TITLE
Fixes for An-Sar/Cyberware#21 and An-Sar/Cyberware#14

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/block/tile/TileEntityBeacon.java
+++ b/src/main/java/flaxbeard/cyberware/common/block/tile/TileEntityBeacon.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import flaxbeard.cyberware.common.item.ItemBrainUpgrade;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
@@ -182,7 +183,7 @@ public class TileEntityBeacon extends TileEntity implements ITickable
 		{
 			if (CyberwareAPI.hasCapability(entity))
 			{
-				if (CyberwareAPI.isCyberwareInstalled(entity, test))
+				if (CyberwareAPI.isCyberwareInstalled(entity, test) && ItemBrainUpgrade.isRadioWorking(entity))
 				{
 					if (EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(entity, test)))
 					{

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemBrainUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemBrainUpgrade.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
@@ -151,9 +152,9 @@ public class ItemBrainUpgrade extends ItemCyberware implements IMenuItem
 		}
 	}
 	
-	private static Map<Integer, Boolean> isContextWorking = new HashMap<Integer, Boolean>();
-	private static Map<Integer, Boolean> isMatrixWorking = new HashMap<Integer, Boolean>();
-	private static Map<Integer, Boolean> isRadioWorking = new HashMap<Integer, Boolean>();
+	private static Map<UUID, Boolean> isContextWorking = new HashMap<UUID, Boolean>();
+	private static Map<UUID, Boolean> isMatrixWorking = new HashMap<UUID, Boolean>();
+	private static Map<UUID, Boolean> isRadioWorking = new HashMap<UUID, Boolean>();
 
 	@SubscribeEvent(priority=EventPriority.NORMAL)
 	public void handleLivingUpdate(CyberwareUpdateEvent event)
@@ -163,51 +164,51 @@ public class ItemBrainUpgrade extends ItemCyberware implements IMenuItem
 		ItemStack test = new ItemStack(this, 1, 3);
 		if (e.ticksExisted % 20 == 0 && CyberwareAPI.isCyberwareInstalled(e, test) && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)))
 		{
-			isContextWorking.put(e.getEntityId(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
+			isContextWorking.put(e.getUniqueID(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
 		}
 		
 		test = new ItemStack(this, 1, 4);
 		if (e.ticksExisted % 20 == 0 && CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			isMatrixWorking.put(e.getEntityId(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
+			isMatrixWorking.put(e.getUniqueID(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
 		}
 		
 		test = new ItemStack(this, 1, 5);
 		if (e.ticksExisted % 20 == 0 && CyberwareAPI.isCyberwareInstalled(e, test) && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)))
 		{
-			isRadioWorking.put(e.getEntityId(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
+			isRadioWorking.put(e.getUniqueID(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
 		}
 		
 	}
 	
 	private boolean isRadioWorking(EntityLivingBase e)
 	{
-		if (!isRadioWorking.containsKey(e.getEntityId()))
+		if (!isRadioWorking.containsKey(e.getUniqueID()))
 		{
-			isRadioWorking.put(e.getEntityId(), false);
+			isRadioWorking.put(e.getUniqueID(), Boolean.FALSE);
 		}
 		
-		return isRadioWorking.get(e.getEntityId());
+		return isRadioWorking.get(e.getUniqueID());
 	}
 	
 	private boolean isContextWorking(EntityLivingBase e)
 	{
-		if (!isContextWorking.containsKey(e.getEntityId()))
+		if (!isContextWorking.containsKey(e.getUniqueID()))
 		{
-			isContextWorking.put(e.getEntityId(), false);
+			isContextWorking.put(e.getUniqueID(), Boolean.FALSE);
 		}
 		
-		return isContextWorking.get(e.getEntityId());
+		return isContextWorking.get(e.getUniqueID());
 	}
 	
 	private boolean isMatrixWorking(EntityLivingBase e)
 	{
-		if (!isMatrixWorking.containsKey(e.getEntityId()))
+		if (!isMatrixWorking.containsKey(e.getUniqueID()))
 		{
-			isMatrixWorking.put(e.getEntityId(), false);
+			isMatrixWorking.put(e.getUniqueID(), Boolean.FALSE);
 		}
 		
-		return isMatrixWorking.get(e.getEntityId());
+		return isMatrixWorking.get(e.getUniqueID());
 	}
 	
 	public boolean isToolEffective(ItemStack tool, IBlockState state)

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemBrainUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemBrainUpgrade.java
@@ -181,7 +181,7 @@ public class ItemBrainUpgrade extends ItemCyberware implements IMenuItem
 		
 	}
 	
-	private boolean isRadioWorking(EntityLivingBase e)
+	public static boolean isRadioWorking(EntityLivingBase e)
 	{
 		if (!isRadioWorking.containsKey(e.getUniqueID()))
 		{

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemFootUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemFootUpgrade.java
@@ -2,6 +2,7 @@ package flaxbeard.cyberware.common.item;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -60,9 +61,9 @@ public class ItemFootUpgrade extends ItemCyberware implements IMenuItem
 	}
 
 	
-	private Map<Integer, Boolean> lastAqua = new HashMap<Integer, Boolean>();
-	private Map<Integer, Integer> lastWheels = new HashMap<Integer, Integer>();
-	private Map<Integer, Float> stepAssist = new HashMap<Integer, Float>();
+	private Map<UUID, Boolean> lastAqua = new HashMap<UUID, Boolean>();
+	private Map<UUID, Integer> lastWheels = new HashMap<UUID, Integer>();
+	private Map<UUID, Float> stepAssist = new HashMap<UUID, Float>();
 
 	@SubscribeEvent(priority=EventPriority.NORMAL)
 	public void handleLivingUpdate(CyberwareUpdateEvent event)
@@ -81,7 +82,7 @@ public class ItemFootUpgrade extends ItemCyberware implements IMenuItem
 			{
 				numLegs++;
 			}
-			boolean last = getLastAqua(e);
+			Boolean last = getLastAqua(e);
 
 			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
 			if (powerUsed)
@@ -93,78 +94,78 @@ public class ItemFootUpgrade extends ItemCyberware implements IMenuItem
 				}
 			}
 			
-			lastAqua.put(e.getEntityId(), powerUsed);
+			lastAqua.put(e.getUniqueID(), powerUsed);
 		}
 		else
 		{
-			lastAqua.put(e.getEntityId(), true);
+			lastAqua.put(e.getUniqueID(), true);
 		}
 		
 		test = new ItemStack(this, 1, 2);
 		if (CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			boolean last = getLastWheels(e) > 0;
+			Boolean last = getLastWheels(e) > 0;
 
 			boolean powerUsed = EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)) && (e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last);
 			if (powerUsed)
 			{
-				if (!stepAssist.containsKey(e.getEntityId()))
+				if (!stepAssist.containsKey(e.getUniqueID()))
 				{
-					stepAssist.put(e.getEntityId(), Math.max(e.stepHeight, .6F));
+					stepAssist.put(e.getUniqueID(), Math.max(e.stepHeight, .6F));
 				}
 				e.stepHeight = 1F;
 				
-				lastWheels.put(e.getEntityId(), 10);
+				lastWheels.put(e.getUniqueID(), 10);
 
 
 			}
-			else if (stepAssist.containsKey(e.getEntityId()) && last)
+			else if (stepAssist.containsKey(e.getUniqueID()) && last)
 			{
 
-				e.stepHeight = stepAssist.get(e.getEntityId());
+				e.stepHeight = stepAssist.get(e.getUniqueID());
 				
-				lastWheels.put(e.getEntityId(), getLastWheels(e) - 1);
+				lastWheels.put(e.getUniqueID(), getLastWheels(e) - 1);
 			}
 			else
 			{
-				lastWheels.put(e.getEntityId(), 0);
+				lastWheels.put(e.getUniqueID(), 0);
 			}
 		
 			
 		}
-		else if (stepAssist.containsKey(e.getEntityId()))
+		else if (stepAssist.containsKey(e.getUniqueID()))
 		{
 
-			e.stepHeight = stepAssist.get(e.getEntityId());
+			e.stepHeight = stepAssist.get(e.getUniqueID());
 			
 			int glw = getLastWheels(e) - 1;
 			
 			if (glw == 0)
 			{
-				stepAssist.remove(e.getEntityId());
+				stepAssist.remove(e.getUniqueID());
 			}
 
-			lastWheels.put(e.getEntityId(), glw);
+			lastWheels.put(e.getUniqueID(), glw);
 
 		}
 	}
 	
 	private boolean getLastAqua(EntityLivingBase e)
 	{
-		if (!lastAqua.containsKey(e.getEntityId()))
+		if (!lastAqua.containsKey(e.getUniqueID()))
 		{
-			lastAqua.put(e.getEntityId(), true);
+			lastAqua.put(e.getUniqueID(), Boolean.TRUE);
 		}
-		return lastAqua.get(e.getEntityId());
+		return lastAqua.get(e.getUniqueID());
 	}
 	
 	private int getLastWheels(EntityLivingBase e)
 	{
-		if (!lastWheels.containsKey(e.getEntityId()))
+		if (!lastWheels.containsKey(e.getUniqueID()))
 		{
-			lastWheels.put(e.getEntityId(), 10);
+			lastWheels.put(e.getUniqueID(), 10);
 		}
-		return lastWheels.get(e.getEntityId());
+		return lastWheels.get(e.getUniqueID());
 	}
 	
 	@Override

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemHandUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemHandUpgrade.java
@@ -76,7 +76,7 @@ public class ItemHandUpgrade extends ItemCyberware implements IMenuItem
 		return other.getItem() == this;
 	}
 	
-	private Map<Integer, Boolean> lastClaws = new HashMap<Integer, Boolean>();
+	private Map<UUID, Boolean> lastClaws = new HashMap<UUID, Boolean>();
 	public static float clawsTime;
 
 	@SubscribeEvent(priority=EventPriority.NORMAL)
@@ -87,7 +87,7 @@ public class ItemHandUpgrade extends ItemCyberware implements IMenuItem
 		ItemStack test = new ItemStack(this, 1, 1);
 		if (CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			boolean last = getLastClaws(e);
+			Boolean last = getLastClaws(e);
 			boolean isEquipped = e.getHeldItemMainhand().isEmpty() && 
 					(e.getPrimaryHand() == EnumHandSide.RIGHT ? 
 							(CyberwareAPI.isCyberwareInstalled(e, new ItemStack(CyberwareContent.cyberlimbs, 1, 1))) : 
@@ -95,7 +95,7 @@ public class ItemHandUpgrade extends ItemCyberware implements IMenuItem
 			if (isEquipped && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)))
 			{
 				this.addUnarmedDamage(e, test);
-				lastClaws.put(e.getEntityId(), true);
+				lastClaws.put(e.getUniqueID(), true);
 
 				if (!last)
 				{
@@ -108,14 +108,14 @@ public class ItemHandUpgrade extends ItemCyberware implements IMenuItem
 			else
 			{
 				this.removeUnarmedDamage(e, test);
-				lastClaws.put(e.getEntityId(), false);
+				lastClaws.put(e.getUniqueID(), false);
 			}
 			
 		}
 		else
 		{
 			
-			lastClaws.put(e.getEntityId(), false);
+			lastClaws.put(e.getUniqueID(), false);
 		}
 	}
 	
@@ -132,11 +132,11 @@ public class ItemHandUpgrade extends ItemCyberware implements IMenuItem
 	
 	private boolean getLastClaws(EntityLivingBase e)
 	{
-		if (!lastClaws.containsKey(e.getEntityId()))
+		if (!lastClaws.containsKey(e.getUniqueID()))
 		{
-			lastClaws.put(e.getEntityId(), false);
+			lastClaws.put(e.getUniqueID(), Boolean.FALSE);
 		}
-		return lastClaws.get(e.getEntityId());
+		return lastClaws.get(e.getUniqueID());
 	}
 	
 	

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemHeartUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemHeartUpgrade.java
@@ -2,6 +2,7 @@ package flaxbeard.cyberware.common.item;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.EntityLivingBase;
@@ -93,7 +94,7 @@ public class ItemHeartUpgrade extends ItemCyberware
 		}
 	}
 	
-	private static Map<Integer, Integer> timesPlatelets = new HashMap<Integer, Integer>();
+	private static Map<UUID, Integer> timesPlatelets = new HashMap<UUID, Integer>();
 
 	@SubscribeEvent
 	public void handleLivingUpdate(CyberwareUpdateEvent event)
@@ -104,14 +105,14 @@ public class ItemHeartUpgrade extends ItemCyberware
 		ItemStack test = new ItemStack(this, 1, 2);
 		if (e.ticksExisted % 20 == 0 && CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			isStemWorking.put(e.getEntityId(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
+			isStemWorking.put(e.getUniqueID(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
 		}
 		
 		
 		test = new ItemStack(this, 1, 1);
 		if (e.ticksExisted % 20 == 0 && CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			isPlateletWorking.put(e.getEntityId(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
+			isPlateletWorking.put(e.getUniqueID(), CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)));
 		}
 		if (e != null && isPlateletWorking(e) && CyberwareAPI.isCyberwareInstalled(e, test))
 		{
@@ -120,20 +121,20 @@ public class ItemHeartUpgrade extends ItemCyberware
 				int t = getPlateletTime(e);
 				if (t >= 40)
 				{
-					timesPlatelets.put(e.getEntityId(), e.ticksExisted);
+					timesPlatelets.put(e.getUniqueID(), e.ticksExisted);
 					e.heal(1);
 				}
 			}
 			else
 			{
-				timesPlatelets.put(e.getEntityId(), e.ticksExisted);
+				timesPlatelets.put(e.getUniqueID(), e.ticksExisted);
 			}
 		}
 		else
 		{
-			if (timesPlatelets.containsKey(e.getEntityId()))
+			if (timesPlatelets.containsKey(e.getUniqueID()))
 			{
-				timesPlatelets.remove(e.getEntityId());
+				timesPlatelets.remove(e.getUniqueID());
 			}
 		}
 		
@@ -142,14 +143,14 @@ public class ItemHeartUpgrade extends ItemCyberware
 			if (isStemWorking(e))
 			{
 				int t = getMedkitTime(e);
-				if (t >= 100 && damageMedkit.get(e.getEntityId()) > 0F)
+				if (t >= 100 && damageMedkit.get(e.getUniqueID()) > 0F)
 				{
 					CyberwarePacketHandler.INSTANCE.sendToAllAround(new ParticlePacket(0, (float) e.posX, (float) e.posY + e.height / 2F, (float) e.posZ), 
 							new TargetPoint(e.world.provider.getDimension(), e.posX, e.posY, e.posZ, 20));
 
-					e.heal(damageMedkit.get(e.getEntityId()));
-					timesMedkit.put(e.getEntityId(), 0);
-					damageMedkit.put(e.getEntityId(), 0F);
+					e.heal(damageMedkit.get(e.getUniqueID()));
+					timesMedkit.put(e.getUniqueID(), 0);
+					damageMedkit.put(e.getUniqueID(), 0F);
 				}
 			}
 
@@ -164,35 +165,35 @@ public class ItemHeartUpgrade extends ItemCyberware
 		}
 	}
 	
-	private static Map<Integer, Boolean> isPlateletWorking = new HashMap<Integer, Boolean>();
+	private static Map<UUID, Boolean> isPlateletWorking = new HashMap<UUID, Boolean>();
 	
 	private boolean isPlateletWorking(EntityLivingBase e)
 	{
-		if (!isPlateletWorking.containsKey(e.getEntityId()))
+		if (!isPlateletWorking.containsKey(e.getUniqueID()))
 		{
-			isPlateletWorking.put(e.getEntityId(), false);
+			isPlateletWorking.put(e.getUniqueID(), false);
 			return false;
 		}
 		
-		return isPlateletWorking.get(e.getEntityId());
+		return isPlateletWorking.get(e.getUniqueID());
 	}
 	
-	private static Map<Integer, Boolean> isStemWorking = new HashMap<Integer, Boolean>();
+	private static Map<UUID, Boolean> isStemWorking = new HashMap<UUID, Boolean>();
 	
 	private boolean isStemWorking(EntityLivingBase e)
 	{
-		if (!isStemWorking.containsKey(e.getEntityId()))
+		if (!isStemWorking.containsKey(e.getUniqueID()))
 		{
-			isStemWorking.put(e.getEntityId(), false);
+			isStemWorking.put(e.getUniqueID(), false);
 			return false;
 		}
 		
-		return isStemWorking.get(e.getEntityId());
+		return isStemWorking.get(e.getUniqueID());
 	}
 	
 	
-	private static Map<Integer, Integer> timesMedkit = new HashMap<Integer, Integer>();
-	private static Map<Integer, Float> damageMedkit = new HashMap<Integer, Float>();
+	private static Map<UUID, Integer> timesMedkit = new HashMap<UUID, Integer>();
+	private static Map<UUID, Float> damageMedkit = new HashMap<UUID, Float>();
 	
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public void handleHurt(LivingHurtEvent event)
@@ -207,8 +208,8 @@ public class ItemHeartUpgrade extends ItemCyberware
 			damageAmount = applyPotionDamageCalculations(e, damageSrc, damageAmount);
 			damageAmount = Math.max(damageAmount - e.getAbsorptionAmount(), 0.0F);
 			
-			damageMedkit.put(e.getEntityId(), damageAmount);
-			timesMedkit.put(e.getEntityId(), e.ticksExisted);
+			damageMedkit.put(e.getUniqueID(), damageAmount);
+			timesMedkit.put(e.getUniqueID(), e.ticksExisted);
 		}
 	}
 	
@@ -262,12 +263,12 @@ public class ItemHeartUpgrade extends ItemCyberware
 	{
 		if (e != null)
 		{
-			if (!timesPlatelets.containsKey(e.getEntityId()))
+			if (!timesPlatelets.containsKey(e.getUniqueID()))
 			{
-				timesPlatelets.put(e.getEntityId(), e.ticksExisted);
+				timesPlatelets.put(e.getUniqueID(), e.ticksExisted);
 				return 0;
 			}
-			return e.ticksExisted - timesPlatelets.get(e.getEntityId());
+			return e.ticksExisted - timesPlatelets.get(e.getUniqueID());
 		}
 		return 0;
 	}
@@ -276,13 +277,13 @@ public class ItemHeartUpgrade extends ItemCyberware
 	{
 		if (e != null)
 		{
-			if (!timesMedkit.containsKey(e.getEntityId()))
+			if (!timesMedkit.containsKey(e.getUniqueID()))
 			{
-				timesMedkit.put(e.getEntityId(), e.ticksExisted);
-				damageMedkit.put(e.getEntityId(), 0F);
+				timesMedkit.put(e.getUniqueID(), e.ticksExisted);
+				damageMedkit.put(e.getUniqueID(), 0F);
 				return 0;
 			}
-			return e.ticksExisted - timesMedkit.get(e.getEntityId());
+			return e.ticksExisted - timesMedkit.get(e.getUniqueID());
 		}
 		return 0;
 	}

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemLowerOrgansUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemLowerOrgansUpgrade.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -33,7 +34,7 @@ public class ItemLowerOrgansUpgrade extends ItemCyberware implements IMenuItem
 
 	}
 	
-	private static Map<Integer, Collection<PotionEffect>> potions = new HashMap<Integer, Collection<PotionEffect>>();
+	private static Map<UUID, Collection<PotionEffect>> potions = new HashMap<UUID, Collection<PotionEffect>>();
 
 	@SubscribeEvent
 	public void handleEatFoodTick(LivingEntityUseItemEvent.Tick event)
@@ -48,7 +49,7 @@ public class ItemLowerOrgansUpgrade extends ItemCyberware implements IMenuItem
 			
 			if (CyberwareAPI.isCyberwareInstalled(p, new ItemStack(this, 1, 0)))
 			{
-				potions.put(p.getEntityId(), new ArrayList<PotionEffect>(p.getActivePotionEffects()));
+				potions.put(p.getUniqueID(), new ArrayList<PotionEffect>(p.getActivePotionEffects()));
 
 			}
 		}

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemLungsUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemLungsUpgrade.java
@@ -18,7 +18,6 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -133,7 +132,7 @@ public class ItemLungsUpgrade extends ItemCyberware
 				if (powerUsed)
 				{
 					//e.moveRelative(0F, .2F * ranks, 0.075F);
-					e.moveRelative(0F, .2F * ranks, 0.075F, 0.0F);
+					e.moveRelative(0F, 0.0F, .2F * ranks, 0.075F);
 				}
 				
 				lastOxygen.put(e.getUniqueID(), powerUsed);

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemLungsUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemLungsUpgrade.java
@@ -2,6 +2,7 @@ package flaxbeard.cyberware.common.item;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
@@ -94,7 +95,7 @@ public class ItemLungsUpgrade extends ItemCyberware
 		}
 	}
 	
-	private Map<Integer, Boolean> lastOxygen = new HashMap<Integer, Boolean>();
+	private Map<UUID, Boolean> lastOxygen = new HashMap<UUID, Boolean>();
 	
 	@SubscribeEvent
 	public void handleLivingUpdate(CyberwareUpdateEvent event)
@@ -123,7 +124,7 @@ public class ItemLungsUpgrade extends ItemCyberware
 		{
 			if ((e.isSprinting() || e instanceof EntityMob) && !e.isInWater() && e.onGround)
 			{
-				boolean last = getLastOxygen(e);
+				Boolean last = getLastOxygen(e);
 
 				int ranks = CyberwareAPI.getCyberwareRank(e, test);
 				test.setCount(ranks);
@@ -135,18 +136,18 @@ public class ItemLungsUpgrade extends ItemCyberware
 					e.moveRelative(0F, .2F * ranks, 0.075F, 0.0F);
 				}
 				
-				lastOxygen.put(e.getEntityId(), powerUsed);
+				lastOxygen.put(e.getUniqueID(), powerUsed);
 			}
 		}
 	}
 	
 	private boolean getLastOxygen(EntityLivingBase e)
 	{
-		if (!lastOxygen.containsKey(e.getEntityId()))
+		if (!lastOxygen.containsKey(e.getUniqueID()))
 		{
-			lastOxygen.put(e.getEntityId(), true);
+			lastOxygen.put(e.getUniqueID(), Boolean.TRUE);
 		}
-		return lastOxygen.get(e.getEntityId());
+		return lastOxygen.get(e.getUniqueID());
 	}
 	
 	@Override

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemMuscleUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemMuscleUpgrade.java
@@ -192,8 +192,7 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 		ItemStack test = new ItemStack(this, 1, 1);
 		if (CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			boolean last = getLastBoostStrength(e);
-
+			Boolean last = getLastBoostStrength(e);
 			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
 			if (powerUsed)
 			{
@@ -222,7 +221,7 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 		test = new ItemStack(this, 1, 0);
 		if (CyberwareAPI.isCyberwareInstalled(e, test) && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)))
 		{
-			boolean last = getLastBoostSpeed(e);
+			Boolean last = getLastBoostSpeed(e);
 			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
 			if (powerUsed)
 			{
@@ -246,7 +245,7 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 	{
 		if (!lastBoostStrength.containsKey(e.getUniqueID()))
 		{
-			lastBoostStrength.put(e.getUniqueID(), true);
+			lastBoostStrength.put(e.getUniqueID(), Boolean.TRUE);
 		}
 		return lastBoostStrength.get(e.getUniqueID());
 	}
@@ -255,7 +254,7 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 	{
 		if (!lastBoostSpeed.containsKey(e.getUniqueID()))
 		{
-			lastBoostSpeed.put(e.getUniqueID(), true);
+			lastBoostSpeed.put(e.getUniqueID(), Boolean.TRUE);
 		}
 		return lastBoostSpeed.get(e.getUniqueID());
 	}

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemMuscleUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemMuscleUpgrade.java
@@ -1,7 +1,7 @@
 package flaxbeard.cyberware.common.item;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 import net.minecraft.entity.Entity;
@@ -105,7 +105,7 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 
 		ItemStack test = new ItemStack(this, 1, 0);
 		int rank = CyberwareAPI.getCyberwareRank(e, test);
-		if (!event.isCanceled() && e instanceof EntityPlayer && (rank > 1) && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)) && getLastBoostSpeed(e))
+		if (!event.isCanceled() && e instanceof EntityPlayer && (rank > 1) && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)) && lastBoostStrength.contains(e.getUniqueID()))
 		{
 			EntityPlayer p = (EntityPlayer) e;
 			if (event.getSource() instanceof EntityDamageSource && !(event.getSource() instanceof EntityDamageSourceIndirect))
@@ -178,8 +178,8 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 		}
 	}
 	
-	private Map<UUID, Boolean> lastBoostSpeed = new HashMap<UUID, Boolean>();
-	private Map<UUID, Boolean> lastBoostStrength = new HashMap<UUID, Boolean>();
+	private Set<UUID> lastBoostSpeed = new HashSet<>();
+	private Set<UUID> lastBoostStrength = new HashSet<>();
 
 	@SubscribeEvent(priority=EventPriority.NORMAL)
 	public void handleLivingUpdate(CyberwareUpdateEvent event)
@@ -192,14 +192,13 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 		ItemStack test = new ItemStack(this, 1, 1);
 		if (CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			Boolean last = getLastBoostStrength(e);
-			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
+			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : lastBoostStrength.contains(e.getUniqueID());
 			if (powerUsed)
 			{
 				if (!e.isInWater() && e.onGround && e.moveForward > 0)
 				{
 					//e.moveRelative(0F, .5F, 0.075F);
-					e.moveRelative(0F, .5F, 0.075F, 0.0F);
+					e.moveRelative(0F, 0.0F,.5F, 0.075F);
 				}
 
 				this.onAdded(e, test);
@@ -210,7 +209,10 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 				this.onRemoved(e, test);
 			}
 			
-			lastBoostStrength.put(e.getUniqueID(), powerUsed);
+			if(powerUsed)
+				lastBoostStrength.add(e.getUniqueID());
+			else
+				lastBoostStrength.remove(e.getUniqueID());
 		}
 		else
 		{
@@ -221,8 +223,7 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 		test = new ItemStack(this, 1, 0);
 		if (CyberwareAPI.isCyberwareInstalled(e, test) && EnableDisableHelper.isEnabled(CyberwareAPI.getCyberware(e, test)))
 		{
-			Boolean last = getLastBoostSpeed(e);
-			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
+			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : lastBoostSpeed.contains(e.getUniqueID());
 			if (powerUsed)
 			{
 				this.onAdded(e, test);
@@ -232,31 +233,16 @@ public class ItemMuscleUpgrade extends ItemCyberware implements IMenuItem
 				this.onRemoved(e, test);
 			}
 			
-			lastBoostSpeed.put(e.getUniqueID(), powerUsed);
+			if(powerUsed)
+				lastBoostSpeed.add(e.getUniqueID());
+			else
+				lastBoostSpeed.remove(e.getUniqueID());
 		}
 		else 
 		{
 			this.onRemoved(e, test);
 			lastBoostSpeed.remove(e.getUniqueID());
 		}
-	}
-	
-	private boolean getLastBoostStrength(EntityLivingBase e)
-	{
-		if (!lastBoostStrength.containsKey(e.getUniqueID()))
-		{
-			lastBoostStrength.put(e.getUniqueID(), Boolean.TRUE);
-		}
-		return lastBoostStrength.get(e.getUniqueID());
-	}
-	
-	private boolean getLastBoostSpeed(EntityLivingBase e)
-	{
-		if (!lastBoostSpeed.containsKey(e.getUniqueID()))
-		{
-			lastBoostSpeed.put(e.getUniqueID(), Boolean.TRUE);
-		}
-		return lastBoostSpeed.get(e.getUniqueID());
 	}
 	
 	@Override

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemSkinUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemSkinUpgrade.java
@@ -54,7 +54,7 @@ public class ItemSkinUpgrade extends ItemCyberware
 		}
 	}
 	
-	private Map<UUID, Boolean> lastImmuno = new HashMap<UUID, Boolean>();
+	private Set<UUID> lastImmuno = new HashSet<>();
 	private static Map<UUID, Collection<PotionEffect>> potions = new HashMap<UUID, Collection<PotionEffect>>();
 
 	@SubscribeEvent(priority = EventPriority.HIGH)
@@ -68,8 +68,7 @@ public class ItemSkinUpgrade extends ItemCyberware
 		ItemStack test = new ItemStack(this, 1, 3);
 		if (CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			Boolean last = lastImmuno(e);
-			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
+			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : lastImmuno.contains(e.getUniqueID());
 			
 			if (!powerUsed && e instanceof EntityPlayer && e.ticksExisted % 100 == 0 && !e.isPotionActive(CyberwareContent.neuropozyneEffect))
 			{
@@ -101,8 +100,12 @@ public class ItemSkinUpgrade extends ItemCyberware
 					}
 				}
 			}
-
-			lastImmuno.put(e.getUniqueID(),powerUsed);
+			
+			if(powerUsed)
+				lastImmuno.add(e.getUniqueID());
+			else
+				lastImmuno.remove(e.getUniqueID());
+			
 			potions.put(e.getUniqueID(), e.getActivePotionEffects());
 		}
 		else
@@ -110,15 +113,6 @@ public class ItemSkinUpgrade extends ItemCyberware
 			lastImmuno.remove(e.getUniqueID());
 			potions.remove(e.getUniqueID());
 		}
-	}
-	
-	private boolean lastImmuno(EntityLivingBase e)
-	{
-		if (!lastImmuno.containsKey(e.getUniqueID()))
-		{
-			lastImmuno.put(e.getUniqueID(), Boolean.TRUE);
-		}
-		return lastImmuno.get(e.getUniqueID());
 	}
 	
 	@Override

--- a/src/main/java/flaxbeard/cyberware/common/item/ItemSkinUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemSkinUpgrade.java
@@ -68,7 +68,7 @@ public class ItemSkinUpgrade extends ItemCyberware
 		ItemStack test = new ItemStack(this, 1, 3);
 		if (CyberwareAPI.isCyberwareInstalled(e, test))
 		{
-			boolean last = lastImmuno(e);
+			Boolean last = lastImmuno(e);
 			boolean powerUsed = e.ticksExisted % 20 == 0 ? CyberwareAPI.getCapability(e).usePower(test, getPowerConsumption(test)) : last;
 			
 			if (!powerUsed && e instanceof EntityPlayer && e.ticksExisted % 100 == 0 && !e.isPotionActive(CyberwareContent.neuropozyneEffect))
@@ -76,9 +76,9 @@ public class ItemSkinUpgrade extends ItemCyberware
 				e.attackEntityFrom(EssentialsMissingHandler.lowessence, 2F);
 			}
 			
-			if (potions.containsKey(e.getEntityId()))
+			if (potions.containsKey(e.getUniqueID()))
 			{
-				Collection<PotionEffect> potionsLastActive = potions.get(e.getEntityId());
+				Collection<PotionEffect> potionsLastActive = potions.get(e.getUniqueID());
 				Collection<PotionEffect> currentEffects = e.getActivePotionEffects();
 				for (PotionEffect cE : currentEffects)
 				{
@@ -116,7 +116,7 @@ public class ItemSkinUpgrade extends ItemCyberware
 	{
 		if (!lastImmuno.containsKey(e.getUniqueID()))
 		{
-			lastImmuno.put(e.getUniqueID(), true);
+			lastImmuno.put(e.getUniqueID(), Boolean.TRUE);
 		}
 		return lastImmuno.get(e.getUniqueID());
 	}


### PR DESCRIPTION
This is a small one. I have tested this locally for a few days with no issues. That said It's not easy replicating the crash from #14 . This should however eliminate most of the potential for the NPE to even happen. The fix for #21 was quick any easy. Tested working fine, we just had a 0 in the wrong space.

- Replaced Instance of Entity.getEntityID with Entity.getUniqueID
- Replaced the HashMaps in ItemMuscleUpgrade and ItemSkinUpgrade with HashSets where applicable. 
- Fixed Hyperoxygenation Boost and Muscle Replacement movement boosts, correct Entity.moveRelative()
- Fixed TileEntityBeacion.isInRange() to properly account for the Radio augment being installed AND powered