### PR TITLE
Adjust Player Tolerance on activating Robosurgeon

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/block/BlockSurgery.java
+++ b/src/main/java/flaxbeard/cyberware/common/block/BlockSurgery.java
@@ -2,6 +2,7 @@ package flaxbeard.cyberware.common.block;
 
 import javax.annotation.Nullable;
 
+import flaxbeard.cyberware.common.CyberwareConfig;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
@@ -72,24 +73,13 @@ public class BlockSurgery extends BlockContainer
 		if (tileentity instanceof TileEntitySurgery)
 		{
 			TileEntitySurgery surgery = (TileEntitySurgery) tileentity;
-			/*if (player.isSneaking())
-			{
-				if (CyberwareAPI.hasCapability(player))
-				{
-					surgery.targetEntity = player;
-					surgery.processUpdate();
-					surgery.targetEntity = null;
-					
-				}
-				
-			}
-			else
-			{*/
-
-				surgery.updatePlayerSlots(player);
-				player.openGui(Cyberware.INSTANCE, 0, worldIn, pos.getX(), pos.getY(), pos.getZ());
-			//}
 			
+			
+			//Ensure the Base Tolerance Attribute has been updated for any Config Changes
+			player.getEntityAttribute(CyberwareAPI.TOLERANCE_ATTR).setBaseValue(CyberwareConfig.ESSENCE);
+
+			surgery.updatePlayerSlots(player);
+			player.openGui(Cyberware.INSTANCE, 0, worldIn, pos.getX(), pos.getY(), pos.getZ());
 		}
 		
 		return true;


### PR DESCRIPTION
Fixes An-Sar/Cyberware#30

Ensures the players Tolerance Attribute's Base Value matches Config Settings
Entity Construction Attribute was being overwritten by the entities stored NBT data, so it's adjusted when the player activates a Robosurgeon. This only adjusts the Base value of the Attribute Instance, so any modifiers to Tolerance the player has won't be affected.

While this requires the player to activate a Robosurgeon and prevents other entities from updating, it seems a better option than having a check added to the CyberwareUpdateEvent that's continually run as only Players really have to pay attention to Tolerance.