### PR TITLE
Fix metabolic generator from ignoring saturation.

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/item/ItemLowerOrgansUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemLowerOrgansUpgrade.java
@@ -118,14 +118,7 @@ public class ItemLowerOrgansUpgrade extends ItemCyberware implements IMenuItem
 						int toRemove = getTicksTilRemove(stack);
 						if (!p.isCreative() && toRemove <= 0)
 						{
-							/*if (p.getFoodStats().getSaturationLevel() >= 1F)
-							{
-								p.getFoodStats().setFoodSaturationLevel(p.getFoodStats().getSaturationLevel() - 1);
-							}
-							else
-							{*/
-								p.getFoodStats().setFoodLevel(p.getFoodStats().getFoodLevel() - 1);
-							/*}*/
+							p.getFoodStats().addExhaustion(6F);
 							toRemove = LibConstants.METABOLIC_USES;
 						}
 						else if (toRemove > 0)


### PR DESCRIPTION
The value of hunger it takes away is probably wrong since I'm not sure the exact number to set it to for an equivalent hunger loss, so that should probably be tweaked.