### PR TITLE
Brain Upgrade reflection fix (fixes #58).

### DIFF
--- a/src/main/java/flaxbeard/cyberware/common/item/ItemBrainUpgrade.java
+++ b/src/main/java/flaxbeard/cyberware/common/item/ItemBrainUpgrade.java
@@ -300,8 +300,7 @@ public class ItemBrainUpgrade extends ItemCyberware implements IMenuItem
                         e.hurtResistantTime = e.maxHurtResistantTime;
                         e.hurtTime = e.maxHurtTime = 10;
 
-                        //Field: EntityLivingBase#lastDamage
-                        ReflectionHelper.setPrivateValue(EntityLivingBase.class, e, 9999F, 47);
+                        ReflectionHelper.setPrivateValue(EntityLivingBase.class, e, 9999F, "lastDamage", "field_110153_bc");
 
                         CyberwarePacketHandler.INSTANCE.sendToAllAround(new DodgePacket(e.getEntityId()), new TargetPoint(e.world.provider.getDimension(), e.posX, e.posY, e.posZ, 50));
                     }


### PR DESCRIPTION
This PR changes the `net.minecraftforge.fml.relauncher.ReflectionHelper.setPrivateValue(...)` invocation that takes field index as an argument to the invocation that takes field names as an argument.
Should fix the issue #58 that happens when field indices are changed inside the `net.minecraft.entity.EntityLivingBase` class.